### PR TITLE
Output non-empty stdout even when exit code is 0

### DIFF
--- a/runny
+++ b/runny
@@ -15,4 +15,8 @@ if [[ $rc != 0 ]]; then
   logger -p 1 -t application.crit "${message}"
   (>&2 echo -en "\033[31m${message}\n\033[0m")
   exit $rc;
+elif [[ "X$output" != "X" ]]; then
+  message="Command exited with zero status but non-empty output: ${output}"
+  logger -p 1 -t application.warning "${message}"
+  echo "${message}"
 fi


### PR DESCRIPTION
It seems worth seeing the output of the command even if there wasn't an error.

However, this may be worth either controlling by an option flag or having as an alternate version of `runny` (such as `runny-all` or something like that) to avoid changing the existing default behavior (unless we want the default behavior changed).